### PR TITLE
activiti-cloud-connector-slack to 0.0.5

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -1,7 +1,7 @@
 dependencies:
 - name: activiti-cloud-connector-slack
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.4
+  version: 0.0.5
 - alias: activiti-cloud
   name: activiti-cloud-full-example
   repository: https://activiti.github.io/activiti-cloud-charts/


### PR DESCRIPTION
Promote activiti-cloud-connector-slack to version 0.0.5